### PR TITLE
fix: replace warning colour

### DIFF
--- a/src/properties/colors.json
+++ b/src/properties/colors.json
@@ -59,7 +59,7 @@
       "dark": { "value": "hsl(0, 97%, 34%)" }
     },
     "warning": {
-      "light": { "value": "hsl(41, 100%, 98%)" },
+      "light": { "value": "hsl(39, 100%, 94%)" },
       "base": { "value": "hsl(41, 100%, 55%)" },
       "mid": { "value": "hsl(41, 89%, 48%)" },
       "dark": { "value": "hsl(41, 100%, 41%)" }


### PR DESCRIPTION
Replace `warningLight` value to

![image](https://user-images.githubusercontent.com/5703687/144022255-6f132da4-67cf-4fde-af45-60ab48dcdfc9.png)
