### PR TITLE
Feat: colour updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom-learning/theme",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0",
   "description": "Design tokens and assets for Atom Learning",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom-learning/theme",
-  "version": "1.0.0",
+  "version": "1.1.0-beta.0",
   "description": "Design tokens and assets for Atom Learning",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/properties/colors.json
+++ b/src/properties/colors.json
@@ -62,7 +62,8 @@
       "light": { "value": "hsl(39, 100%, 94%)" },
       "base": { "value": "hsl(41, 100%, 55%)" },
       "mid": { "value": "hsl(41, 89%, 48%)" },
-      "dark": { "value": "hsl(41, 100%, 41%)" }
+      "dark": { "value": "hsl(41, 100%, 41%)" },
+      "text": { "value": "hsl(24, 100%, 37%)" }
     },
 
     "subject": {

--- a/src/properties/colors.json
+++ b/src/properties/colors.json
@@ -20,7 +20,7 @@
 
     "primary": {
       "light": { "value": "hsl(217, 92%, 97%)" },
-      "base": { "value": "hsl(217,92,51)" },
+      "base": { "value": "hsl(217, 92,51)" },
       "mid": { "value": "hsl(223, 78%, 45%)" },
       "dark": { "value": "hsl(228, 82%, 35%)" }
     },

--- a/src/properties/colors.json
+++ b/src/properties/colors.json
@@ -20,7 +20,7 @@
 
     "primary": {
       "light": { "value": "hsl(217, 92%, 97%)" },
-      "base": { "value": "hsl(217, 92,51)" },
+      "base": { "value": "hsl(217, 92%, 51%)" },
       "mid": { "value": "hsl(223, 78%, 45%)" },
       "dark": { "value": "hsl(228, 82%, 35%)" }
     },

--- a/src/properties/colors.json
+++ b/src/properties/colors.json
@@ -20,7 +20,7 @@
 
     "primary": {
       "light": { "value": "hsl(217, 92%, 97%)" },
-      "base": { "value": "hsl(217, 92%, 54%)" },
+      "base": { "value": "hsl(217,92,51)" },
       "mid": { "value": "hsl(223, 78%, 45%)" },
       "dark": { "value": "hsl(228, 82%, 35%)" }
     },


### PR DESCRIPTION
Jira ticket: https://atomlearningltd.atlassian.net/jira/software/projects/DS/boards/27?selectedIssue=DS-62

Adds a `warningText` colour so that we have an accessible orange colour for text in our warning components (this will be used in the forthcoming `InlineMessage` component).

Updates `primaryBase` to an almost imperceptibly different blue that passes AA requirements for contrast.