### PR TITLE
Ds 349/omit aspect ratio tokens in sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atom-learning/theme",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Design tokens and assets for Atom Learning",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/formatters/scss-map-flat.js
+++ b/src/formatters/scss-map-flat.js
@@ -29,6 +29,16 @@ const formatter = (dictionary) => {
   const properties = dictionary.allProperties.reduce((obj, curr, i) => {
     const { type, category, item } = curr.attributes
     const group = `${category}-${type}`
+
+    // the ratio values include a slash (`/`) which is deprecated in the sass version we
+    // use. As it's legacy and we are going to remove it (and not use the tokens in places
+    // where sass is used), we decided that is not worth the hassle to try to make it
+    // work with sass, so here we omit sass output for the ratios
+    if (type === 'ratio') {
+      return obj
+    }
+
+
     return {
       ...obj,
       [group]: { ...obj[group], [item]: curr.value }

--- a/src/formatters/scss-map-flat.js
+++ b/src/formatters/scss-map-flat.js
@@ -30,15 +30,6 @@ const formatter = (dictionary) => {
     const { type, category, item } = curr.attributes
     const group = `${category}-${type}`
 
-    // the ratio values include a slash (`/`) which is deprecated in the sass version we
-    // use. As it's legacy and we are going to remove it (and not use the tokens in places
-    // where sass is used), we decided that is not worth the hassle to try to make it
-    // work with sass, so here we omit sass output for the ratios
-    if (type === 'ratio') {
-      return obj
-    }
-
-
     return {
       ...obj,
       [group]: { ...obj[group], [item]: curr.value }

--- a/style.config.js
+++ b/style.config.js
@@ -14,8 +14,12 @@ module.exports = {
         {
           destination: '_scales.scss',
           format: 'custom/format/scss-map-flat',
+          // purposely omitting category === 'ratios'
+          // The ratio values include a slash (`/`) which is deprecated in the sass
+          // version we use. As sass is legacy for us and we are going to remove it, we
+          // decided that is not worth the hassle to make it work
           filter: ({ attributes: { category } }) =>
-            category === 'size' || category === 'effects' || category === 'ratios'
+            category === 'size' || category === 'effects'
         }
       ],
       actions: ['merge-files']


### PR DESCRIPTION
[JIRA](https://atomlearningltd.atlassian.net/browse/DS-349)

## Description

The ratio values include a slash (`/`) which is deprecated in the sass version we use. As it's legacy and we are going to remove it (and not use the tokens in places where sass is used), we decided that is not worth the hassle to try to make it work with sass, so here we omit sass output for the ratios